### PR TITLE
fix: possible NPE if date is null in database

### DIFF
--- a/src/main/java/dev/pcvolkmer/onco/datamapper/mapper/ConsentMvDataMapper.java
+++ b/src/main/java/dev/pcvolkmer/onco/datamapper/mapper/ConsentMvDataMapper.java
@@ -27,10 +27,9 @@ import dev.pcvolkmer.mv64e.mtb.Provision;
 import dev.pcvolkmer.onco.datamapper.ResultSet;
 import dev.pcvolkmer.onco.datamapper.datacatalogues.ConsentMvCatalogue;
 import dev.pcvolkmer.onco.datamapper.datacatalogues.ConsentMvVerlaufCatalogue;
-import org.jspecify.annotations.NullMarked;
-
 import java.util.*;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Mapper class to load and map diagnosis data from database table 'dk_dnpm_consentmv'


### PR DESCRIPTION
This should not occur in default installations but a null value might occur, if database has been
modified from external tools.