### PR TITLE
feat: sanitize values for TNM-T

### DIFF
--- a/src/main/java/dev/pcvolkmer/mv64e/datamapper/mapper/KpaTumorausbreitungDataMapper.java
+++ b/src/main/java/dev/pcvolkmer/mv64e/datamapper/mapper/KpaTumorausbreitungDataMapper.java
@@ -101,7 +101,10 @@ public class KpaTumorausbreitungDataMapper extends AbstractSubformDataMapper<Tum
     var tnmt = resultSet.getString("tnmt");
     if (null != tnmtprefix && tnmt != null && !tnmt.isBlank()) {
       tnpmClassificationBuilder.tumor(
-          Coding.builder().code(String.format("%sT%s", tnmtprefix, sanitizeTValue(tnmt))).system("UICC").build());
+          Coding.builder()
+              .code(String.format("%sT%s", tnmtprefix, sanitizeTValue(tnmt)))
+              .system("UICC")
+              .build());
       hasContent = true;
     }
 

--- a/src/test/java/dev/pcvolkmer/mv64e/datamapper/mapper/KpaTumorausbreitungDataMapperTest.java
+++ b/src/test/java/dev/pcvolkmer/mv64e/datamapper/mapper/KpaTumorausbreitungDataMapperTest.java
@@ -104,9 +104,9 @@ class KpaTumorausbreitungDataMapperTest {
                 .build());
     assertThat(actual.getOtherClassifications()).hasSize(1);
     assertThat(actual.getOtherClassifications().get(0).getCode()).isEqualTo("tumor-free");
-    assertThat(actual.getTnmClassification().getTumor().getCode()).isEqualTo("T0");
-    assertThat(actual.getTnmClassification().getNodes().getCode()).isEqualTo("N0");
-    assertThat(actual.getTnmClassification().getMetastasis().getCode()).isEqualTo("M0");
+    assertThat(actual.getTnmClassification().getTumor().getCode()).isEqualTo("pT0");
+    assertThat(actual.getTnmClassification().getNodes().getCode()).isEqualTo("pN0");
+    assertThat(actual.getTnmClassification().getMetastasis().getCode()).isEqualTo("pM0");
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Since oncostar uses different coding than DNPM:DIP, a sanitizing of possible values is required.