### PR TITLE
feat: add study name as display to study references

### DIFF
--- a/src/main/java/dev/pcvolkmer/mv64e/datamapper/mapper/JsonToStudyMapper.java
+++ b/src/main/java/dev/pcvolkmer/mv64e/datamapper/mapper/JsonToStudyMapper.java
@@ -56,7 +56,9 @@ public class JsonToStudyMapper {
                           .id(studie.getId())
                           .system(getStudySystem(studie.getSystem()))
                           .type("Study")
-                          .display(studie.getStudy()) // Datenmodell v2.1: Über den "display"-Wert an der Referenz kann der Studien-Name gesetzt werden.
+                          .display(
+                              studie.getStudy()) // Datenmodell v2.1: Über den "display"-Wert an der
+                          // Referenz kann der Studien-Name gesetzt werden.
                           .build())
               .collect(Collectors.toList());
     } catch (Exception e) {
@@ -98,12 +100,12 @@ public class JsonToStudyMapper {
       this.id = id;
     }
 
-    public void setStudy(String study) {
-      this.study = study;
-    }
-
     public String getStudy() {
       return this.study;
+    }
+
+    public void setStudy(String study) {
+      this.study = study;
     }
 
     public String getSystem() {

--- a/src/test/java/dev/pcvolkmer/mv64e/datamapper/mapper/JsonToStudyMapperTest.java
+++ b/src/test/java/dev/pcvolkmer/mv64e/datamapper/mapper/JsonToStudyMapperTest.java
@@ -42,7 +42,10 @@ class JsonToStudyMapperTest {
 
     var study = actual.get(0);
     assertThat(study.getId()).isEqualTo("NCT12345678");
-    assertThat(study.getDisplay()).isEqualTo("TestInhibitor"); // Datenmodell V2.1: Über den "display"-Wert an der Referenz kann der Studien-Name gesetzt werden.
+    assertThat(study.getDisplay())
+        .isEqualTo(
+            "TestInhibitor"); // Datenmodell V2.1: Über den "display"-Wert an der Referenz kann der
+    // Studien-Name gesetzt werden.
     assertThat(study.getSystem()).isEqualTo(StudySystem.NCT);
     assertThat(study.getType()).isEqualTo("Study");
   }


### PR DESCRIPTION
(cherry picked from commit 14fb305f24575bfcfedfad84d18862f44dd73706)

// Datenmodell v2.1: Über den "display"-Wert an der Referenz kann der Studien-Name gesetzt werden.