### PR TITLE
feat!: map plain text pipeline names to URIs

### DIFF
--- a/src/main/java/dev/pcvolkmer/mv64e/datamapper/mapper/MolekulargenetikNgsDataMapper.java
+++ b/src/main/java/dev/pcvolkmer/mv64e/datamapper/mapper/MolekulargenetikNgsDataMapper.java
@@ -27,6 +27,9 @@ import dev.pcvolkmer.mv64e.datamapper.genes.GeneUtils;
 import dev.pcvolkmer.mv64e.datamapper.mapper.exceptionhandler.tuples.Tuple;
 import dev.pcvolkmer.mv64e.datamapper.mapper.exceptionhandler.tuples.Tuple2;
 import dev.pcvolkmer.mv64e.mtb.*;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -651,10 +654,16 @@ public class MolekulargenetikNgsDataMapper implements DataMapper<SomaticNgsRepor
     var seqPipeline = osMolResultSet.getString("seqpipeline");
     var seqPipelinePv = osMolResultSet.getInteger("seqpipeline_propcat_version");
     if (null != seqPipeline && null != seqPipelinePv) {
-      builder.pipeline(
-          propertyCatalogue.getShortdescOrEmptyByCodeAndVersion(seqPipeline, seqPipelinePv));
+      final var pipeline =
+          propertyCatalogue.getShortdescOrEmptyByCodeAndVersion(seqPipeline, seqPipelinePv);
+      if (!pipeline.isBlank()) {
+        builder.pipeline(mapPipelineUri(pipeline).toString());
+      } else {
+        builder.pipeline(pipeline);
+      }
+
     } else {
-      builder.pipeline("SeqPipeline not specified.");
+      builder.pipeline(mapPipelineUri(null).toString());
     }
 
     var referenceGenome = osMolResultSet.getString("referenzgenom");
@@ -779,6 +788,21 @@ public class MolekulargenetikNgsDataMapper implements DataMapper<SomaticNgsRepor
     } else {
       logger.error("No RNA fusion strand found for '{}'.", value);
       return null;
+    }
+  }
+
+  @NonNull
+  private static URI mapPipelineUri(@Nullable String value) {
+    if (null == value) {
+      return URI.create("https://pipelines.dnpm.dev/00000000-0000-0000-0000-000000000000");
+    }
+    try {
+      return URI.create(value);
+    } catch (IllegalArgumentException e) {
+      return URI.create(
+          String.format(
+              "https://pipelines.dnpm.dev?q=%s",
+              URLEncoder.encode(value.trim(), StandardCharsets.UTF_8)));
     }
   }
 }

--- a/src/test/java/dev/pcvolkmer/mv64e/datamapper/mapper/MolekulargenetikNgsDataMapperTest.java
+++ b/src/test/java/dev/pcvolkmer/mv64e/datamapper/mapper/MolekulargenetikNgsDataMapperTest.java
@@ -13,11 +13,14 @@ import dev.pcvolkmer.mv64e.datamapper.test.PropcatColumn;
 import dev.pcvolkmer.mv64e.datamapper.test.TestResultSet;
 import dev.pcvolkmer.mv64e.mtb.*;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -993,5 +996,49 @@ class MolekulargenetikNgsDataMapperTest {
                             .isEqualTo(expectedValue);
                       });
             });
+  }
+
+  public static Stream<Arguments> providePipelineAndUri() {
+    return Stream.of(
+        // This does not result in an exception
+        Arguments.of("", ""),
+        Arguments.of("http://example.com/pipeline", "http://example.com/pipeline"),
+        // This will result in an IllegalArgumentException when creating java.net.URI from string and this will fail in DNPM:DIP
+        Arguments.of(null, "https://pipelines.dnpm.dev/00000000-0000-0000-0000-000000000000"),
+        Arguments.of("Meine Testpipeline", "https://pipelines.dnpm.dev?q=Meine+Testpipeline"),
+        Arguments.of(
+            "Meine Testpipeline / Beispiel für MV §64e",
+            "https://pipelines.dnpm.dev?q=Meine+Testpipeline+%2F+Beispiel+f%C3%BCr+MV+%C2%A764e"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("providePipelineAndUri")
+  void shouldMapPipelineToUri(String value, String pipelineUri) {
+    doAnswer(
+            invocationOnMock -> {
+              var id = invocationOnMock.getArgument(0, Integer.class);
+              return TestResultSet.withColumns(
+                  Column.name(Column.ID).value(id),
+                  Column.name(Column.PATIENTEN_ID).value(4711),
+                  PropcatColumn.name("AnalyseMethoden").values("S"),
+                  PropcatColumn.name("entnahmemethode").value("B"),
+                  PropcatColumn.name("probenmaterial").value("T"),
+                  PropcatColumn.name("sequenziergeraet").value("FancySeq"),
+                  PropcatColumn.name("seqkittyp").value("FancySeqKitTyp"),
+                  PropcatColumn.name("seqkithersteller").value("FancySeqKitHersteller"),
+                  PropcatColumn.name("seqpipeline").value(value));
+            })
+        .when(molekulargenetikCatalogue)
+        .getById(anyInt());
+
+    when(molekulargenetikCatalogue.isOfTypeSeqencing(anyInt())).thenReturn(true);
+
+    when(propertyCatalogue.getShortdescOrEmptyByCodeAndVersion(anyString(), anyInt()))
+        .thenReturn(value);
+
+    var actual = this.mapper.getById(1);
+
+    assertThat(actual).isNotNull();
+    assertThat(actual.getMetadata().get(0).getPipeline()).isEqualTo(pipelineUri);
   }
 }

--- a/src/test/java/dev/pcvolkmer/mv64e/datamapper/mapper/MolekulargenetikNgsDataMapperTest.java
+++ b/src/test/java/dev/pcvolkmer/mv64e/datamapper/mapper/MolekulargenetikNgsDataMapperTest.java
@@ -1003,7 +1003,8 @@ class MolekulargenetikNgsDataMapperTest {
         // This does not result in an exception
         Arguments.of("", ""),
         Arguments.of("http://example.com/pipeline", "http://example.com/pipeline"),
-        // This will result in an IllegalArgumentException when creating java.net.URI from string and this will fail in DNPM:DIP
+        // This will result in an IllegalArgumentException when creating java.net.URI from string
+        // and this will fail in DNPM:DIP
         Arguments.of(null, "https://pipelines.dnpm.dev/00000000-0000-0000-0000-000000000000"),
         Arguments.of("Meine Testpipeline", "https://pipelines.dnpm.dev?q=Meine+Testpipeline"),
         Arguments.of(


### PR DESCRIPTION
Since DNPM-Datamodel 2.1 requires pipelines to be URIs and DNPM:DIP throws `IllegalArgumentException`s which result in validation errors if a plain pipeline name is provided, we will map names into a valid URI but keep valid URIs as is.

In the future, these generated URIs can point to a description of the used pipeline, hosted at dnpm.dev.