### PR TITLE
fix: set Java compiler source encoding to UTF-8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,7 @@ tasks.test {
 }
 
 tasks.withType<JavaCompile> {
+    options.encoding = "UTF-8"
     options.errorprone {
         disableAllChecks = true
         option("NullAway:OnlyNullMarked", "true")


### PR DESCRIPTION
Without an explicit encoding option the compiler falls back to the JVM default (windows-1252 on this machine). Source files are UTF-8, so non-ASCII literals such as German umlauts were being mis-read, causing double-encoded percent sequences in URLEncoder output and a **failing test in MolekulargenetikNgsDataMapperTest.**