### PR TITLE
fix: use tumor-morphology from DNPM UF Histologie

### DIFF
--- a/src/main/java/dev/pcvolkmer/mv64e/datamapper/mapper/KpaHistologieDataMapper.java
+++ b/src/main/java/dev/pcvolkmer/mv64e/datamapper/mapper/KpaHistologieDataMapper.java
@@ -159,8 +159,8 @@ public class KpaHistologieDataMapper extends AbstractSubformDataMapper<Histology
             .patient(resultSet.getPatientReference())
             .specimen(Reference.builder().id(osMolGen.getId().toString()).type("Specimen").build());
 
-    var morphologie = osMolGen.getString("morphologie");
-    var morphologiePropcatVersion = osMolGen.getInteger("morphologie_propcat_version");
+    var morphologie = resultSet.getString("morphologie");
+    var morphologiePropcatVersion = resultSet.getInteger("morphologie_propcat_version");
 
     if (null == morphologie || null == morphologiePropcatVersion) {
       return Optional.empty();

--- a/src/test/java/dev/pcvolkmer/mv64e/datamapper/mapper/KpaHistologieDataMapperTest.java
+++ b/src/test/java/dev/pcvolkmer/mv64e/datamapper/mapper/KpaHistologieDataMapperTest.java
@@ -85,6 +85,7 @@ class KpaHistologieDataMapperTest {
                       Column.name(Column.PATIENTEN_ID).value(42),
                       Column.name("histologie").value(100),
                       DateColumn.name("erstellungsdatum").value("2000-01-01"),
+                      PropcatColumn.name("morphologie").value("8000/0"),
                       Column.name("tumorzellgehalt").value(80))));
 
       when(this.molekulargenetikCatalogue.isAvailable(anyInt())).thenReturn(true);
@@ -96,6 +97,19 @@ class KpaHistologieDataMapperTest {
                   Column.name(Column.PATIENTEN_ID).value(42),
                   Column.name("histologie").value(100),
                   DateColumn.name("datum").value("2000-01-01")));
+
+      doAnswer(
+              invocationOnMock -> {
+                var testPropertyData =
+                    Map.of(
+                        "8000/0",
+                        new PropertyCatalogue.Entry("8000/0", "Benigne Neoplasie o.n.A.", ""));
+
+                var code = invocationOnMock.getArgument(0, String.class);
+                return testPropertyData.get(code);
+              })
+          .when(propertyCatalogue)
+          .getByCodeAndVersion(anyString(), anyInt());
     }
 
     @Test
@@ -123,6 +137,19 @@ class KpaHistologieDataMapperTest {
                                     .build())
                             .value(0.8)
                             .build());
+                assertThat(histologyReport.getResults().getTumorMorphology())
+                    .satisfies(
+                        tumorMorphology -> {
+                          assertThat(tumorMorphology.getValue())
+                              .isEqualTo(
+                                  Coding.builder()
+                                      .code("8000/0")
+                                      .display("Benigne Neoplasie o.n.A.")
+                                      .system("urn:oid:2.16.840.1.113883.6.43.1")
+                                      .build());
+                          assertThat(tumorMorphology.getPatient().getId()).isEqualTo("42");
+                          assertThat(tumorMorphology.getSpecimen().getId()).isEqualTo("100");
+                        });
               });
     }
 


### PR DESCRIPTION
This fixes an issue introduced in 0.9.0 that tries to fetch the tumor-morphology from OS.Molekulargenetik, which is not available.

The behavior in case of OS.Pathologiebefund is unchanged. Morphology will be fetched from OS.Pathologiebefund.