### PR TITLE
feat(dnpm-to-fhir): add mapping file to OncotreeMapper

### DIFF
--- a/dnpm-to-fhir/src/main/java/dev/pcvolkmer/onco/datamapper/fhir/diagnosis/OncotreeMapper.java
+++ b/dnpm-to-fhir/src/main/java/dev/pcvolkmer/onco/datamapper/fhir/diagnosis/OncotreeMapper.java
@@ -19,6 +19,8 @@
 
 package dev.pcvolkmer.onco.datamapper.fhir.diagnosis;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import dev.pcvolkmer.mv64e.model.HistologyReport;
 import dev.pcvolkmer.mv64e.model.MtbDiagnosis;
@@ -28,34 +30,21 @@ import dev.pcvolkmer.onco.datamapper.fhir.ObservationMapper;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
+import java.io.UncheckedIOException;
 import java.util.List;
-import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.hl7.fhir.r4.model.*;
 import org.jspecify.annotations.Nullable;
 
 public class OncotreeMapper extends ObservationMapper<MtbDiagnosis>
     implements ManyMapper<PatientRecord, Observation> {
 
-  private List<OncotreeOntologyMapping> oncotreeOntologyMappings = new ArrayList<>();
+  private static final String MAPPING_FILE = "ontology_mappings.txt";
+  private final List<OncotreeOntologyMapping> oncotreeOntologyMappings;
 
   public OncotreeMapper() {
-    try {
-      final var inputStream =
-          Objects.requireNonNull(
-              this.getClass().getClassLoader().getResourceAsStream("ontology_mappings.txt"));
-      final var buf = new BufferedReader(new InputStreamReader(inputStream));
-      String line;
-      while (null != (line = buf.readLine())) {
-        final var parts = line.split("\\s");
-        if (parts.length >= 5) {
-          oncotreeOntologyMappings.add(new OncotreeOntologyMapping(parts[0], parts[3], parts[4]));
-        }
-      }
-      inputStream.close();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    this.oncotreeOntologyMappings = loadOncotreeOntologyMappings();
   }
 
   @Override
@@ -90,6 +79,8 @@ public class OncotreeMapper extends ObservationMapper<MtbDiagnosis>
                     .setCode("371469007")
                     .setDisplay("Histologic grade of neoplasm (observable entity)")));
 
+    result.setSubject(this.getPatientReference(sourceItem));
+
     if (null != sourceItem.getRecordedOn()) {
       final var dateTimeType = new DateTimeType(sourceItem.getRecordedOn());
       dateTimeType.setPrecision(TemporalPrecisionEnum.DAY);
@@ -106,61 +97,130 @@ public class OncotreeMapper extends ObservationMapper<MtbDiagnosis>
       return;
     }
 
-    diagnoses.forEach(
-        diagnosis -> {
-          final var result = this.map(diagnosis);
-          result.setSubject(this.getPatientReference(diagnosis));
-
-          final var topography = diagnosis.getTopography();
-          final var histologies = diagnosis.getHistology();
-          if (null != topography && null != histologies) {
-            histologies.forEach(
-                ref -> {
-                  final var histology = this.getHistologie(sourceItem, ref.getId());
-                  if (null != histology) {
-                    // TODO: add value codable concept here - mapped from histology and
-                    // topography to oncotree - for now: fake value
-                    result.setValue(
-                        new CodeableConcept()
-                            .addCoding(
-                                new Coding()
-                                    .setSystem("http://data.mskcc.org/ontologies/oncotree")
-                                    .setCode(
-                                        // TODO: Replace!
-                                        String.format(
-                                            "placeholder-oncotree:%s-%s",
-                                            histology
-                                                .getResults()
-                                                .getTumorMorphology()
-                                                .getValue()
-                                                .getCode(),
-                                            topography.getCode()))));
-                  }
-                });
-          }
-          bundle
-              .addEntry()
-              .setResource(result)
-              .getRequest()
-              .setMethod(Bundle.HTTPVerb.PUT)
-              .setUrl(this.getRequestUrl(diagnosis));
-        });
-  }
-
-  @Nullable
-  private String findOncotreeCode(String histology, String topography) {
-    for (final var oncotreeOntologyMapping : oncotreeOntologyMappings) {
-      if (histology.equals(oncotreeOntologyMapping.icdO3TCode)
-          && topography.equals(oncotreeOntologyMapping.icdO3MCode)) {
-        return oncotreeOntologyMapping.oncotreeCode;
-      }
+    for (final var diagnosis : diagnoses) {
+      createObservation(sourceItem, diagnosis)
+          .ifPresent(
+              result ->
+                  bundle
+                      .addEntry()
+                      .setResource(result)
+                      .getRequest()
+                      .setMethod(Bundle.HTTPVerb.PUT)
+                      .setUrl(this.getRequestUrl(diagnosis)));
     }
-    return null;
   }
 
   @Override
   public List<Observation> mapToMany(PatientRecord sourceItem) {
-    throw new UnsupportedOperationException("Not implemented");
+    final var diagnoses = sourceItem.getDiagnoses();
+
+    if (diagnoses == null) {
+      return List.of();
+    }
+
+    return diagnoses.stream()
+        .map(diagnosis -> createObservation(sourceItem, diagnosis))
+        .flatMap(Optional::stream)
+        .collect(Collectors.toList());
+  }
+
+  // Only create Oncotree Observation if there is an oncotree code
+  private Optional<Observation> createObservation(
+      PatientRecord patientRecord, MtbDiagnosis diagnosis) {
+
+    return findOncotreeCode(patientRecord, diagnosis)
+        .map(
+            oncotreeCode -> {
+              final var observation = this.map(diagnosis);
+
+              observation.setValue(
+                  new CodeableConcept()
+                      .addCoding(
+                          new Coding()
+                              .setSystem("http://data.mskcc.org/ontologies/oncotree")
+                              .setCode(oncotreeCode)));
+
+              return observation;
+            });
+  }
+
+  // If there are multiple histology-codes only the first one that leads to a mathc with an oncotree
+  // code is used
+  private Optional<String> findOncotreeCode(PatientRecord patientRecord, MtbDiagnosis diagnosis) {
+
+    final var topography = diagnosis.getTopography();
+    final var histologyReferences = diagnosis.getHistology();
+
+    if (topography == null || topography.getCode() == null || histologyReferences == null) {
+      return Optional.empty();
+    }
+
+    final var icdO3Topography = topography.getCode();
+
+    for (final var histologyReference : histologyReferences) {
+      if (histologyReference == null || histologyReference.getId() == null) {
+        continue;
+      }
+
+      final var histologyReport = getHistologie(patientRecord, histologyReference.getId());
+      if (histologyReport == null) {
+        continue;
+      }
+
+      final var icdO3Morphology =
+          histologyReport.getResults().getTumorMorphology().getValue().getCode();
+      if (icdO3Morphology == null) {
+        continue;
+      }
+
+      final var oncotreeCode = findOncotreeCode(icdO3Topography, icdO3Morphology);
+      if (oncotreeCode.isPresent()) {
+        return oncotreeCode;
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  // Find Oncotree code via mapping file using Topography (Localisation) and Morphology (Histology)
+  // codes
+  private Optional<String> findOncotreeCode(String icdO3Topography, String icdO3Morphology) {
+
+    return this.oncotreeOntologyMappings.stream()
+        .filter(
+            mapping ->
+                icdO3Topography.equals(mapping.icdO3TCode)
+                    && icdO3Morphology.equals(mapping.icdO3MCode))
+        .map(mapping -> mapping.oncotreeCode)
+        .findFirst();
+  }
+
+  private List<OncotreeOntologyMapping> loadOncotreeOntologyMappings() {
+    final var inputStream = OncotreeMapper.class.getClassLoader().getResourceAsStream(MAPPING_FILE);
+
+    if (inputStream == null) {
+      throw new IllegalStateException("Oncotree mapping file not found: " + MAPPING_FILE);
+    }
+
+    try (var reader = new BufferedReader(new InputStreamReader(inputStream, UTF_8))) {
+
+      return reader
+          .lines()
+          // skip header
+          .skip(1)
+          // keep empty columns
+          .map(line -> line.split("\t", -1))
+          .filter(fields -> fields.length >= 5)
+          .map(fields -> new OncotreeOntologyMapping(fields[0], fields[3], fields[4]))
+          // filter rows where ICDO_TOPOGRAPHY_CODE or ICDO_MORPHOLOGY_CODE are blank
+          .filter(mapping -> !mapping.icdO3TCode.isBlank())
+          .filter(mapping -> !mapping.icdO3MCode.isBlank())
+          .collect(Collectors.toList());
+
+    } catch (IOException e) {
+      throw new UncheckedIOException(
+          "Oncotree mapping file could not be loaded: " + MAPPING_FILE, e);
+    }
   }
 
   @Nullable

--- a/dnpm-to-fhir/src/snapshotTest/java/dev/pcvolkmer/onco/datamapper/fhir/diagnosis/OncotreeMapperTest.java
+++ b/dnpm-to-fhir/src/snapshotTest/java/dev/pcvolkmer/onco/datamapper/fhir/diagnosis/OncotreeMapperTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class OncotreeMapperTest extends DnpmToFhirTest {
 
   @ParameterizedTest
-  @ValueSource(strings = {"diagnosis-with-patient.json"})
+  @ValueSource(strings = {"diagnosis-with-patient-for-oncotree.json"})
   void shouldAddOncotreeToBundle(String filename) throws IOException {
     var inputStream =
         Objects.requireNonNull(this.getClass().getClassLoader().getResourceAsStream(filename));

--- a/dnpm-to-fhir/src/snapshotTest/java/dev/pcvolkmer/onco/datamapper/fhir/diagnosis/approvals/OncotreeMapperTest.shouldAddOncotreeToBundle.diagnosis-with-patient-for-oncotree.json.approved.fhir.json
+++ b/dnpm-to-fhir/src/snapshotTest/java/dev/pcvolkmer/onco/datamapper/fhir/diagnosis/approvals/OncotreeMapperTest.shouldAddOncotreeToBundle.diagnosis-with-patient-for-oncotree.json.approved.fhir.json
@@ -26,7 +26,7 @@
       "valueCodeableConcept": {
         "coding": [ {
           "system": "http://data.mskcc.org/ontologies/oncotree",
-          "code": "placeholder-oncotree:9181/3-C53.8"
+          "code": "PAAD"
         } ]
       }
     },

--- a/dnpm-to-fhir/src/snapshotTest/resources/diagnosis-with-patient-for-oncotree.json
+++ b/dnpm-to-fhir/src/snapshotTest/resources/diagnosis-with-patient-for-oncotree.json
@@ -1,0 +1,189 @@
+{
+  "patient": {
+    "id": "4ba7adb6-ee5a-40d5-89fe-670cb6af86c6",
+    "gender": {
+      "code": "female",
+      "display": "Weiblich",
+      "system": "Gender"
+    },
+    "birthDate": "1957-01-26",
+    "dateOfDeath": "2007-01-26",
+    "healthInsurance": {
+      "type": {
+        "code": "GKV",
+        "display": "gesetzliche Krankenversicherung",
+        "system": "http://fhir.de/CodeSystem/versicherungsart-de-basis"
+      },
+      "reference": {
+        "id": "1234567890",
+        "system": "https://www.dguv.de/arge-ik",
+        "display": "AOK",
+        "type": "HealthInsurance"
+      }
+    },
+    "address": {
+      "municipalityCode": "12345"
+    },
+    "age": {
+      "value": 50,
+      "unit": "Years"
+    },
+    "vitalStatus": {
+      "code": "deceased",
+      "display": "Verstorben",
+      "system": "dnpm-dip/patient/vital-status"
+    }
+  },
+  "diagnoses": [
+    {
+      "id": "8aa2be4a-14a6-4dd3-9fad-0bb1362c92c2",
+      "patient": {
+        "id": "4ba7adb6-ee5a-40d5-89fe-670cb6af86c6",
+        "type": "Patient"
+      },
+      "recordedOn": "2003-09-26",
+      "type": {
+        "history": [
+          {
+            "value": {
+              "code": "main",
+              "display": "Hauptdiagnose",
+              "system": "dnpm-dip/mtb/diagnosis/type"
+            },
+            "date": "2003-09-26"
+          }
+        ]
+      },
+      "code": {
+        "code": "C25.9",
+        "display": "Bösartige Neubildung des Pankreas, mehrere Teilbereiche überlappend",
+        "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+        "version": "2025"
+      },
+      "topography": {
+        "code": "C25.9",
+        "display": "Pankreas o.n.A.",
+        "system": "urn:oid:2.16.840.1.113883.6.43.1",
+        "version": "Zweite Revision"
+      },
+      "grading": {
+        "history": [
+          {
+            "date": "2003-09-26",
+            "codes": [
+              {
+                "code": "2",
+                "display": "2 = mäßig differenziert",
+                "system": "https://www.basisdatensatz.de/feld/161/grading"
+              },
+              {
+                "code": "4",
+                "display": "Glioblastoma",
+                "system": "dnpm-dip/mtb/who-grading-cns-tumors",
+                "version": "2021"
+              }
+            ]
+          }
+        ]
+      },
+      "staging": {
+        "history": [
+          {
+            "date": "2003-09-26",
+            "method": {
+              "code": "clinical",
+              "display": "Klinisch",
+              "system": "dnpm-dip/mtb/tumor-staging/method"
+            },
+            "tnmClassification": {
+              "tumor": {
+                "code": "T0",
+                "system": "UICC"
+              },
+              "nodes": {
+                "code": "N0",
+                "system": "UICC"
+              },
+              "metastasis": {
+                "code": "M1",
+                "system": "UICC"
+              }
+            },
+            "otherClassifications": [
+              {
+                "code": "metastasized",
+                "display": "Metastasiert",
+                "system": "dnpm-dip/mtb/diagnosis/kds-tumor-spread"
+              }
+            ]
+          }
+        ]
+      },
+      "guidelineTreatmentStatus": {
+        "code": "non-exhausted",
+        "display": "Leitlinien nicht ausgeschöpft",
+        "system": "dnpm-dip/mtb/diagnosis/guideline-treatment-status"
+      },
+      "histology": [
+        {
+          "id": "549143c4-aacb-42aa-914f-5ddf8adf1046",
+          "type": "HistologyReport"
+        }
+      ],
+      "notes": [
+        "Notes on the tumor diagnosis..."
+      ]
+    }
+  ],
+  "histologyReports": [
+    {
+      "id": "549143c4-aacb-42aa-914f-5ddf8adf1046",
+      "patient": {
+        "id": "4ba7adb6-ee5a-40d5-89fe-670cb6af86c6",
+        "type": "Patient"
+      },
+      "specimen": {
+        "id": "84aa1d75-0ba6-4266-b8e1-7a1337e44a3a",
+        "type": "TumorSpecimen"
+      },
+      "issuedOn": "2025-12-10",
+      "results": {
+        "tumorMorphology": {
+          "id": "b3845b08-6c6b-41df-8b74-0d795c4351f0",
+          "patient": {
+            "id": "4ba7adb6-ee5a-40d5-89fe-670cb6af86c6",
+            "type": "Patient"
+          },
+          "specimen": {
+            "id": "84aa1d75-0ba6-4266-b8e1-7a1337e44a3a",
+            "type": "TumorSpecimen"
+          },
+          "value": {
+            "code": "8140/3",
+            "display": "Adenocarcinoma, NOS",
+            "system": "urn:oid:2.16.840.1.113883.6.43.1",
+            "version": "Zweite Revision"
+          },
+          "note": "Notes..."
+        },
+        "tumorCellContent": {
+          "id": "268b9f18-2e62-46b6-a40b-fda09478b209",
+          "patient": {
+            "id": "4ba7adb6-ee5a-40d5-89fe-670cb6af86c6",
+            "type": "Patient"
+          },
+          "specimen": {
+            "id": "84aa1d75-0ba6-4266-b8e1-7a1337e44a3a",
+            "type": "TumorSpecimen"
+          },
+          "method": {
+            "code": "histologic",
+            "display": "Histologisch",
+            "system": "dnpm-dip/mtb/tumor-cell-content/method"
+          },
+          "value": 0.9068795360732212
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Änderungen:
- Der OncotreeMapper verwendet jetzt die `ontology_mappings.txt``
- Den InputStreamReader hab ich etwas angepasst, damit der den Header der File skipped und die TSV richtig verarbeitet
- Platzhalter-Logik ersetzt
- Bei ``findOncotreeCode`` war topo & morpho noch vertauscht was die Spaltennamen angeht. Ich habs jetzt so gelöst, dass er aus der Liste der Histologien, die erste nimmt bei der er zusammen mit dem Topographie-Code ein Match findet. Findet er gar kein Match, wird auch keine Oncotree-Observation erzeugt
- Neue Testfile ``diagnosis-with-patient-for-oncotree.json``, die der anderen File entspricht, aber ICD-03-Codes setzt, für die man auch einen Oncotree-Code findet (Hab eine Beispiel-Kombination aus der realen Welt genommen: ``C25.9`` mit ``8140/3``)